### PR TITLE
Handle missing metadata in dataset processing

### DIFF
--- a/extract_features.py
+++ b/extract_features.py
@@ -157,11 +157,25 @@ def process_dataset(dataset_type='train'):
                 'gps_accuracy', 'network_type', 'device_model'
             ]
             for key in metadata_keys:
-                features[key] = data[key].item() if isinstance(data[key], np.ndarray) else data[key]
+                if key in data.files:
+                    value = data[key]
+                    if isinstance(value, np.ndarray):
+                        try:
+                            value = value.item()
+                        except ValueError:
+                            # Non-scalar arrays are unlikely in metadata but keep as-is
+                            pass
+                    features[key] = value
+                else:
+                    # Some data files may not include the full metadata set
+                    features[key] = None
 
-            features['driver_id'] = f"D{int(features['driver_id'])}"
-            features['session_id'] = f"S{int(features['session_id'])}"
-            features['timestamp'] = pd.to_datetime(features['timestamp'])
+            if features['driver_id'] is not None:
+                features['driver_id'] = f"D{int(features['driver_id'])}"
+            if features['session_id'] is not None:
+                features['session_id'] = f"S{int(features['session_id'])}"
+            if features['timestamp'] is not None:
+                features['timestamp'] = pd.to_datetime(features['timestamp'])
 
             all_features.append(features)
 

--- a/tests/test_process_dataset.py
+++ b/tests/test_process_dataset.py
@@ -1,0 +1,48 @@
+import sys
+import numpy as np
+import pandas as pd
+from pathlib import Path
+import shutil
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from extract_features import process_dataset
+
+
+def test_process_dataset_handles_missing_metadata():
+    data_dir = Path('data/raw/unit_test_missing')
+    if data_dir.exists():
+        shutil.rmtree(data_dir)
+    data_dir.mkdir(parents=True)
+
+    signal = np.zeros((100, 3))
+    np.savez(
+        data_dir / 'sample1.npz',
+        phone_signal=signal,
+        timestamp='2024-01-01',
+        weather='sunny',
+        driver_id=1,
+        vehicle_type='car',
+        speed_bin='slow',
+        road_type='urban',
+        time_of_day='day',
+        temperature=20,
+        humidity=50,
+        altitude=100,
+        session_id=1,
+        firmware_version='1.0',
+        calibration_status='good',
+        battery_level=80,
+        network_type='4G',
+        device_model='X'
+    )  # intentionally missing gps_accuracy
+
+    try:
+        df = process_dataset(dataset_type='unit_test_missing')
+        assert 'gps_accuracy' in df.columns
+        assert pd.isna(df.loc[0, 'gps_accuracy'])
+    finally:
+        shutil.rmtree(data_dir)
+        output_csv = Path('data/unit_test_missing.csv')
+        if output_csv.exists():
+            output_csv.unlink()
+


### PR DESCRIPTION
## Summary
- avoid KeyError when metadata keys are missing in `.npz` files
- normalize optional driver/session/timestamp fields only when present
- test dataset processing with missing `gps_accuracy` metadata

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1e565f3f8832184dbe271b059f173